### PR TITLE
add settings to part_list and remove mail merge element

### DIFF
--- a/lib/docx_tools/mail_merge.rb
+++ b/lib/docx_tools/mail_merge.rb
@@ -6,7 +6,7 @@ module DocxTools
 
     def initialize(file_object)
       self.document  = Document.new(file_object)
-      self.part_list = PartList.new(document, %w[document.main header footer])
+      self.part_list = PartList.new(document, %w[document.main header footer settings])
       process_merge_fields
     end
 
@@ -72,6 +72,12 @@ module DocxTools
       def process_merge_fields
         self.part_list.each_part do |part|
           part.root.remove_attribute('Ignorable')
+          
+          # remove mail merge element from settings
+          part.xpath('.//w:mailMerge').each do |mail_merge|
+            mail_merge.remove
+          end
+          
 
           part.xpath('.//w:fldSimple/..').each do |parent|
             parent.children.each do |child|


### PR DESCRIPTION
By adding the settings file so that we can remove the mail merge element, the merged document will no longer trigger the launch of mail merge manager when it's opened.

A secondary issue is that when we create the mail merge template, a local path to the data source is stored in settings, which throws an error for any other user downloading the merged document. 

We solve both problems with this fix.