### PR TITLE
nest merge field in additional r element

### DIFF
--- a/lib/docx_tools/mail_merge.rb
+++ b/lib/docx_tools/mail_merge.rb
@@ -84,9 +84,11 @@ module DocxTools
               match_data = REGEXP.match(child.attribute('instr'))
               next if (child.node_name != 'fldSimple') || !match_data
 
+              r_elem = Nokogiri::XML::Node.new('r', part)
               new_tag = Nokogiri::XML::Node.new('MergeField', part)
+              new_tag.parent = r_elem
               new_tag.content = match_data[1]
-              child.replace(new_tag)
+              child.replace(r_elem)
             end
           end
 


### PR DESCRIPTION
When we updated the way mergefields were processed to accommodate styles, the behavior for replacing unstyled fldSimple tags was also impacted.

By nesting the mergefield in an additional r tag, unstyled fields will now also produce valid xml.
